### PR TITLE
🧪 Add unit tests for keyValueTypeArrayToObject in json.util.js

### DIFF
--- a/apps/backend/__tests__/unit/utils/json.util.test.js
+++ b/apps/backend/__tests__/unit/utils/json.util.test.js
@@ -1,0 +1,67 @@
+const { keyValueTypeArrayToObject } = require('../../../utils/json.util');
+
+describe('jsonUtil', () => {
+  describe('keyValueTypeArrayToObject', () => {
+    it('should convert string type correctly', () => {
+      const input = [{ key: 'name', value: 'John', type: 'string' }];
+      const expected = { name: 'John' };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should convert number type correctly', () => {
+      const input = [{ key: 'age', value: '30', type: 'number' }];
+      const expected = { age: 30 };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should convert boolean type correctly (true)', () => {
+      const input = [{ key: 'active', value: 'true', type: 'boolean' }];
+      const expected = { active: true };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should convert boolean type correctly (false)', () => {
+      const input = [{ key: 'active', value: 'false', type: 'boolean' }];
+      const expected = { active: false };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should convert object type correctly (valid JSON)', () => {
+      const input = [{ key: 'data', value: '{"id": 1}', type: 'object' }];
+      const expected = { data: { id: 1 } };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should handle invalid JSON for object type by returning null', () => {
+      const input = [{ key: 'data', value: 'invalid json', type: 'object' }];
+      const expected = { data: null };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should handle unknown types by returning the value as-is', () => {
+      const input = [{ key: 'data', value: 'some value', type: 'unknown' }];
+      const expected = { data: 'some value' };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should handle an empty array by returning an empty object', () => {
+      const input = [];
+      const expected = {};
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+
+    it('should handle multiple items in the array', () => {
+      const input = [
+        { key: 'name', value: 'John', type: 'string' },
+        { key: 'age', value: '30', type: 'number' },
+        { key: 'active', value: 'true', type: 'boolean' }
+      ];
+      const expected = {
+        name: 'John',
+        age: 30,
+        active: true
+      };
+      expect(keyValueTypeArrayToObject(input)).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a comprehensive suite of unit tests for the `keyValueTypeArrayToObject` utility function in `apps/backend/utils/json.util.js`.

The following scenarios are now covered:
- Successful conversion of 'string' type values.
- Successful conversion of 'number' type values.
- Successful conversion of 'boolean' type values (both 'true' and 'false').
- Successful parsing of 'object' type values from JSON strings.
- Graceful handling of invalid JSON in 'object' type values (returns null).
- Handling of unknown types (returns the value as-is).
- Handling of empty input arrays (returns an empty object).
- Handling of multiple items in the input array.

These tests ensure the utility's reliability and provide a safety net for future refactoring.